### PR TITLE
[BUGFIX] Remove Entities from All Namespaces when Unregistering

### DIFF
--- a/src/ShardCache.php
+++ b/src/ShardCache.php
@@ -291,6 +291,7 @@ final class ShardCache
                 }
             }
         } else {
+            $this->unregisterGuidFromAllNamespaces($guid);
             unset($this->memoryCache->entities[$guid]);
         }
         $this->saveChanges();


### PR DESCRIPTION
When calling unregisterEntity method without the namespace argument,
the entity will now automatically be unregistered from all namespaces
as well.

Fixes #6